### PR TITLE
Only err for exceptional errors

### DIFF
--- a/examples/secrets.rs
+++ b/examples/secrets.rs
@@ -3,13 +3,19 @@
 
 use azure_identity::DefaultAzureCredential;
 use azure_security_keyvault_secrets::SecretClient;
+use dotazure::error::{ErrorKind, ResultExt};
 use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    dotazure::load()?;
+    const ENV_VAR_NAME: &str = "AZURE_KEYVAULT_URL";
 
-    let endpoint = env::var("AZURE_KEYVAULT_URL")?;
+    if dotazure::load()? {
+        eprintln!("loaded environment variables");
+    }
+
+    let endpoint = env::var(ENV_VAR_NAME)
+        .with_context_fn(ErrorKind::NotFound, || format!("{ENV_VAR_NAME} not set"))?;
     let credential = DefaultAzureCredential::new()?;
     let client = SecretClient::new(&endpoint, credential.clone(), None)?;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -74,7 +74,7 @@ impl AzdContextBuilder {
         let current_dir: PathBuf = path.into();
         if !current_dir.exists() {
             return Err(Error::new(
-                ErrorKind::Io,
+                ErrorKind::NotFound,
                 format!("{} does not exist", current_dir.display()),
             ));
         }
@@ -119,7 +119,7 @@ impl AzdContextBuilder {
 
         let Some(project_dir) = project_dir.map(Into::<PathBuf>::into) else {
             return Err(Error::new(
-                ErrorKind::Io,
+                ErrorKind::NotFound,
                 "no project exists; to create a new project, run `azd init`",
             ));
         };
@@ -135,7 +135,7 @@ impl AzdContextBuilder {
 
                 config.default_environment.ok_or_else(|| {
                     Error::new(
-                        ErrorKind::InvalidData,
+                        ErrorKind::NotFound,
                         format!("'{}' does not define `defaultEnvironment`", path.display()),
                     )
                 })?


### PR DESCRIPTION
Returns a boolean whether the .env file was found and loaded successfully. Errors are only returned for exceptional circumstances like files that should be directories, vice versa, or corrupt / invalid data files we need to read.
